### PR TITLE
Feat/map filter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "uplc==0.5.6",
-        "pluthon==0.2.14",
+        "pluthon==0.2.15",
         "pycardano==0.7.2",
         "frozenlist==1.3.3",
         "pyaiken==0.4.0",


### PR DESCRIPTION
Uses combined map/filter functions for list comprehensions with if-expressions

This reduces the computational effort in the performance tests by 10%

before
```
(venv) ➜  eopsin-lang git:(feat/performance_test) aiken uplc eval sum_of_range_listcomp_old/script.uplc "(con data #18f4)"

Result
------

(con data #1939aa)


Costs
-----
cpu: 1496410744
memory: 4043019

Budget
------
cpu: 8503589256
memory: 9956981
```

After
```
(venv) ➜  eopsin-lang git:(feat/performance_test) aiken uplc eval sum_of_range_listcomp/script.uplc "(con data #18f4)"    

Result
------

(con data #1939aa)


Costs
-----
cpu: 1378963435
memory: 3671348

Budget
------
cpu: 8621036565
memory: 10328652

```